### PR TITLE
fix: remove routine events check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.7] - 2024-11-18
+
+### 🚀 Features
+
+- Asset Hub transactions with fee currency
+  - Autofill tip with asset
+  - Pass asset id into transaction constructor to properly select fee currency
+
+### 🧪 Testing
+
+- Test cases to cover partial withdrawal and Asset Gub transfers
+
 ## [0.2.6] - 2024-11-01
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "substrate-constructor"
 version = "0.1.0"
-source = "git+https://github.com/Alzymologist/substrate-constructor#901469814d0d903db8150c90a2b3d124cde8785e"
+source = "git+https://github.com/Alzymologist/substrate-constructor#4faed1fa180359b6fe41ec90c4f1ec37a982da92"
 dependencies = [
  "bitvec",
  "external-memory-tools",
@@ -3403,7 +3403,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "substrate-constructor"
 version = "0.1.0"
-source = "git+https://github.com/Alzymologist/substrate-constructor#d6791fedc53f31bc42eef250decbd9054a738875"
+source = "git+https://github.com/Alzymologist/substrate-constructor#901469814d0d903db8150c90a2b3d124cde8785e"
 dependencies = [
  "bitvec",
  "external-memory-tools",
@@ -3403,7 +3403,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf1549fba25a6fcac22785b61698317d958e96cac72a59102ea45b9ae64692"
+checksum = "701bac17e9b55e0f95067c428ebcb46496587f08e8cf4ccc0fe5903bea10dbb8"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -1283,6 +1283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,7 +1496,7 @@ dependencies = [
  "mnemonic-external",
  "names",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.2",
  "reqwest",
  "scale-info",
  "serde",
@@ -1980,8 +1989,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
- "impl-codec",
- "uint",
+ "impl-codec 0.6.0",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -2716,7 +2736,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "substrate-constructor"
 version = "0.1.0"
-source = "git+https://github.com/Alzymologist/substrate-constructor#540559207e640bfa158358cdbf736eb488c57100"
+source = "git+https://github.com/Alzymologist/substrate-constructor#d6791fedc53f31bc42eef250decbd9054a738875"
 dependencies = [
  "bitvec",
  "external-memory-tools",
@@ -2724,19 +2744,18 @@ dependencies = [
  "hex",
  "num-bigint",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.13.1",
  "scale-info",
  "sp-arithmetic",
  "sp-crypto-hashing",
  "substrate-crypto-light",
  "substrate_parser",
- "thiserror",
 ]
 
 [[package]]
 name = "substrate-crypto-light"
 version = "0.1.0"
-source = "git+https://github.com/Alzymologist/substrate-crypto-light#8b5d43144a622f4fdbd8f4147a302e6ff4af894c"
+source = "git+https://github.com/Alzymologist/substrate-crypto-light#e1c07e19ccb19862accc2771d3b7ec0f86c80a36"
 dependencies = [
  "base58",
  "blake2b_simd",
@@ -2756,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "substrate_parser"
 version = "0.6.1"
-source = "git+https://github.com/Alzymologist/substrate-parser#09f98462f5179bf3c5b6c323c53f7438caf03f06"
+source = "git+https://github.com/Alzymologist/substrate-parser#ed388d969b803b4713622378bb716b2032b2c7fe"
 dependencies = [
  "bitvec",
  "external-memory-tools",
@@ -2765,7 +2784,7 @@ dependencies = [
  "num-bigint",
  "parity-scale-codec",
  "plot_icon",
- "primitive-types",
+ "primitive-types 0.13.1",
  "scale-info",
  "sp-arithmetic",
  "sp-crypto-hashing",
@@ -3190,6 +3209,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "substrate-constructor"
 version = "0.1.0"
-source = "git+https://github.com/Alzymologist/substrate-constructor#4faed1fa180359b6fe41ec90c4f1ec37a982da92"
+source = "git+https://github.com/Alzymologist/substrate-constructor#09c877f9ef228508e9d1fbeb3f66bcb782b70bb6"
 dependencies = [
  "bitvec",
  "external-memory-tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "kalatori"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ahash",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,15 +1275,6 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
@@ -1496,7 +1487,7 @@ dependencies = [
  "mnemonic-external",
  "names",
  "parity-scale-codec",
- "primitive-types 0.12.2",
+ "primitive-types",
  "reqwest",
  "scale-info",
  "serde",
@@ -1984,24 +1975,13 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec 0.6.0",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
- "impl-codec 0.7.0",
- "uint 0.10.0",
+ "impl-codec",
+ "uint",
 ]
 
 [[package]]
@@ -2744,7 +2724,7 @@ dependencies = [
  "hex",
  "num-bigint",
  "parity-scale-codec",
- "primitive-types 0.13.1",
+ "primitive-types",
  "scale-info",
  "sp-arithmetic",
  "sp-crypto-hashing",
@@ -2784,7 +2764,7 @@ dependencies = [
  "num-bigint",
  "parity-scale-codec",
  "plot_icon",
- "primitive-types 0.13.1",
+ "primitive-types",
  "scale-info",
  "sp-arithmetic",
  "sp-crypto-hashing",
@@ -3203,18 +3183,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ axum-macros = "0.4"
 primitive-types = { version = "0.12", features = ["codec"] }
 jsonrpsee = { version = "0.24", features = ["ws-client"] }
 thiserror = "1"
-frame-metadata = "16"
+frame-metadata = "17"
 const-hex = "1"
 codec = { package = "parity-scale-codec", version = "3", features = [
     "chain-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 tracing = "0.1"
 scale-info = "2"
 axum-macros = "0.4"
-primitive-types = { version = "0.12", features = ["codec"] }
+primitive-types = { version = "0.13", features = ["codec"] }
 jsonrpsee = { version = "0.24", features = ["ws-client"] }
 thiserror = "1"
 frame-metadata = "17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kalatori"
 authors = ["Alzymologist Oy <contact@zymologia.fi>"]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "A gateway daemon for Kalatori."
 license = "GPL-3.0-or-later"

--- a/src/chain/payout.rs
+++ b/src/chain/payout.rs
@@ -118,6 +118,7 @@ pub async fn payout(
             block,
             block_number,
             0,
+            currency.asset_id,
         )?;
 
         let sign_this = batch_transaction

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -133,12 +133,12 @@ pub fn start_chain_watch(
                                         Ok(true) => {
                                             state.order_paid(id.clone()).await;
                                             id_remove_list.push(id.to_owned());
-                                        }
-                                        Ok(false) => (
+                                        },
+                                        Ok(false) => {
                                             if invoice.death.0 <= now {
-                                                        id_remove_list.push(id.to_owned());
+                                                id_remove_list.push(id.to_owned());
                                             }
-                                        ),
+                                        },
                                         Err(e) => {
                                             tracing::warn!("account fetch error: {0:?}", e);
                                         }

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -135,7 +135,7 @@ pub fn start_chain_watch(
                                             id_remove_list.push(id.to_owned());
                                         }
                                         Ok(false) => (
-                                            if invoice.death.0 >= now {
+                                            if invoice.death.0 <= now {
                                                         id_remove_list.push(id.to_owned());
                                             }
                                         ),

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -116,52 +116,39 @@ pub fn start_chain_watch(
                                     break;
                                 }
 
-                                match transfer_events(
-                                    &client,
-                                    &block,
-                                    &watcher.metadata,
-                                )
-                                    .await {
-                                        Ok(events) => {
-                                        let mut id_remove_list = Vec::new();
-                                        let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
+                                let mut id_remove_list = Vec::new();
+                                let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
 
-                                        for (id, invoice) in &watched_accounts {
-                                            if events.iter().any(|event| was_balance_received_at_account(&invoice.address, &event.0.fields)) {
-                                                match invoice.check(&client, &watcher, &block).await {
-                                                    Ok(true) => {
-                                                        state.order_paid(id.clone()).await;
+                                // Important! There used to be a significant oprimisation that
+                                // watched events and checked only accounts that have tranfers into
+                                // them in given block; this was found to be unreliable: there are
+                                // ways to transfer funds without emitting a transfer event (one
+                                // notable example is through asset exchange procedure directed
+                                // straight into invoice account), and probably even without any
+                                // reliably expected event (through XCM). Thus we just scan all
+                                // accounts, every time. Please submit a PR or an issue if you
+                                // figure out a reliable optimization for this.
+                                for (id, invoice) in &watched_accounts {
+                                    match invoice.check(&client, &watcher, &block).await {
+                                        Ok(true) => {
+                                            state.order_paid(id.clone()).await;
+                                            id_remove_list.push(id.to_owned());
+                                        }
+                                        Ok(false) => (
+                                            if invoice.death.0 >= now {
                                                         id_remove_list.push(id.to_owned());
-                                                    }
-                                                    Ok(false) => (),
-                                                    Err(e) => {
-                                                        tracing::warn!("account fetch error: {0:?}", e);
-                                                    }
-                                                }
-                                            } else if invoice.death.0 >= now {
-                                                match invoice.check(&client, &watcher, &block).await {
-                                                    Ok(paid) => {
-                                                        if paid {
-                                                            state.order_paid(id.clone()).await;
-                                                        }
-
-                                                        id_remove_list.push(id.to_owned());
-                                                    }
-                                                    Err(e) => {
-                                                        tracing::warn!("account fetch error: {0:?}", e);
-                                                    }
-                                                }
                                             }
+                                        ),
+                                        Err(e) => {
+                                            tracing::warn!("account fetch error: {0:?}", e);
                                         }
-                                        for id in id_remove_list {
-                                            watched_accounts.remove(&id);
-                                        }
-                                    },
-                                    Err(e) => {
-                                        tracing::warn!("Events fetch error {e} at {}", chain.name);
-                                        break;
-                                    },
                                     }
+                                }
+                                    
+                                for id in id_remove_list {
+                                    watched_accounts.remove(&id);
+                                };
+
                                 tracing::debug!("Block {} from {} processed successfully", block.to_string(), chain.name);
                             }
                             ChainTrackerRequest::WatchAccount(request) => {

--- a/src/chain/tracker.rs
+++ b/src/chain/tracker.rs
@@ -144,7 +144,7 @@ pub fn start_chain_watch(
                                         }
                                     }
                                 }
-                                    
+
                                 for id in id_remove_list {
                                     watched_accounts.remove(&id);
                                 };

--- a/src/chain/utils.rs
+++ b/src/chain/utils.rs
@@ -214,6 +214,7 @@ pub fn construct_batch_transaction(
     block: BlockHash,
     block_number: u32,
     nonce: u32,
+    asset: Option<u32>,
 ) -> Result<TransactionToFill, ChainError> {
     let mut transaction_to_fill = TransactionToFill::init(&mut (), metadata, genesis_hash.0)?;
 
@@ -296,6 +297,13 @@ pub fn construct_batch_transaction(
 
     transaction_to_fill.populate_block_info(Some(block.0), Some(block_number.into()));
     transaction_to_fill.populate_nonce(nonce);
+    if let Some(asset) = asset {
+        transaction_to_fill.try_default_tip_assets_in_given_asset<E: ExternalMemory, M: AsFillMetadata<E>>(
+            &mut (),
+            &metadata,
+            asset,
+        );
+    }
 
     for ext in transaction_to_fill.extensions.iter_mut() {
         if ext.finalize().is_none() {

--- a/src/chain/utils.rs
+++ b/src/chain/utils.rs
@@ -298,7 +298,7 @@ pub fn construct_batch_transaction(
     transaction_to_fill.populate_block_info(Some(block.0), Some(block_number.into()));
     transaction_to_fill.populate_nonce(nonce);
     if let Some(asset) = asset {
-        transaction_to_fill.try_default_tip_assets_in_given_asset<E: ExternalMemory, M: AsFillMetadata<E>>(
+        transaction_to_fill.try_default_tip_assets_in_given_asset(
             &mut (),
             &metadata,
             asset,

--- a/src/chain/utils.rs
+++ b/src/chain/utils.rs
@@ -298,11 +298,7 @@ pub fn construct_batch_transaction(
     transaction_to_fill.populate_block_info(Some(block.0), Some(block_number.into()));
     transaction_to_fill.populate_nonce(nonce);
     if let Some(asset) = asset {
-        transaction_to_fill.try_default_tip_assets_in_given_asset(
-            &mut (),
-            metadata,
-            asset,
-        );
+        transaction_to_fill.try_default_tip_assets_in_given_asset(&mut (), metadata, asset);
     }
 
     for ext in transaction_to_fill.extensions.iter_mut() {

--- a/src/chain/utils.rs
+++ b/src/chain/utils.rs
@@ -300,7 +300,7 @@ pub fn construct_batch_transaction(
     if let Some(asset) = asset {
         transaction_to_fill.try_default_tip_assets_in_given_asset(
             &mut (),
-            &metadata,
+            metadata,
             asset,
         );
     }


### PR DESCRIPTION
There used to be a significant optimisation that watched events and checked only accounts that have tranfers into them in given block; this was found to be unreliable: there are ways to transfer funds without emitting a transfer event (one notable example is through asset exchange procedure directed straight into invoice account), and probably even without any reliably expected event (through XCM). Thus we just scan all accounts, every time. Please submit a PR or an issue if you figure out a reliable optimization for this.